### PR TITLE
Remove duplicated settings branch name

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -63,7 +63,7 @@
   "permissions": {
     "private-browsing": true
   },
-  "preferences-branch": "extensions.tabscroll",
+  "preferences-branch": "tabscroll",
   "preferences": [
     {
         "name": "downScrollsLeft",


### PR DESCRIPTION
The current value results in
`extensions.extensions.tabscroll` being used as root for the simple-prefs settings. This patch removes the redundant part.