### PR TITLE
Fix CI tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 node_js: stable
 addons:
-  firefox: latest
+  firefox: "47.0"
 env:
   global:
   - DISPLAY=:99.0


### PR DESCRIPTION
Firefox 48 seems to have broken jpm test, likely due to enforced signing requirements. Until a solution is found (either through signing or using dev edition), limit the Firefox version to 47.