### PR TITLE
Implement eslint import checking.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,25 @@
+{
+    "plugins": [
+        "babel-plugin-transform-es2015-template-literals",
+        "babel-plugin-transform-es2015-literals",
+        "babel-plugin-transform-es2015-function-name",
+        "babel-plugin-transform-es2015-arrow-functions",
+        "babel-plugin-transform-es2015-block-scoped-functions",
+        "babel-plugin-transform-es2015-classes",
+        "babel-plugin-transform-es2015-object-super",
+        "babel-plugin-transform-es2015-shorthand-properties",
+        "babel-plugin-transform-es2015-duplicate-keys",
+        "babel-plugin-transform-es2015-computed-properties",
+        "babel-plugin-transform-es2015-sticky-regex",
+        "babel-plugin-transform-es2015-unicode-regex",
+        "babel-plugin-check-es2015-constants",
+        "babel-plugin-transform-es2015-spread",
+        "babel-plugin-transform-es2015-parameters",
+        "babel-plugin-transform-es2015-destructuring",
+        "babel-plugin-transform-es2015-block-scoping",
+        "babel-plugin-transform-es2015-typeof-symbol",
+        "babel-plugin-transform-es2015-modules-commonjs",
+        [ "babel-plugin-transform-regenerator", { "async": false, "asyncGenerators": false } ],
+        [ "babel-plugin-import-rename", { "^(addon-sdk\/lib\/sdk)": "sdk" } ]
+    ]
+}

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,8 @@
     "root": true,
     "extends": [ 
         "eslint:recommended", 
-        "plugin:import/errors" ],
+        "plugin:import/errors" 
+    ],
     "parserOptions": {
         "ecmaVersion": 6,
         "sourceType": "module",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,9 @@
     // Configuring env and plugins: http://eslint.org/docs/user-guide/configuring
     // Adding rules: http://eslint.org/docs/rules/
     "root": true,
-    "extends": "eslint:recommended",
+    "extends": [ 
+        "eslint:recommended", 
+        "plugin:import/errors" ],
     "parserOptions": {
         "ecmaVersion": 6,
         "sourceType": "module",
@@ -10,6 +12,9 @@
             "impliedStrict": true
         }
     },
+    "plugins": [
+        "import"
+    ],
     "env": {
       "node": true,
       "es6": true
@@ -21,6 +26,7 @@
         "no-var": "error",
         "no-duplicate-imports": "error",
         "no-path-concat": "error",
-        "prefer-const": "error"
+        "prefer-const": "error",
+        "import/no-commonjs": "error"
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -27,6 +27,7 @@
         "no-duplicate-imports": "error",
         "no-path-concat": "error",
         "prefer-const": "error",
-        "import/no-commonjs": "error"
+        "import/no-commonjs": "error",
+        "import/export": "error"
     }
 }

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -1,11 +1,11 @@
-import gulp     from "gulp";
-import del      from "del";
-import jeditor  from "gulp-json-editor";
-import babel    from "gulp-babel";
-import moment   from "moment";
-import utils    from "jpm/lib/utils";
-import xpi      from "jpm/lib/xpi";
-import path     from "path";
+import gulp    from "gulp";
+import del     from "del";
+import jeditor from "gulp-json-editor";
+import babel   from "gulp-babel";
+import moment  from "moment";
+import utils   from "jpm/lib/utils";
+import xpi     from "jpm/lib/xpi";
+import path    from "path";
 
 const config = {
     in: "src/",

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,10 @@
+{
+    "compilerOptions": {
+        "target": "es2015",
+        "module": "es2015"
+    },
+    "exclude": [
+        "node_modules",
+        "dist"
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -11,10 +11,15 @@
     "lint": "eslint ./src",
     "browser": "jpm --addon-dir ./dist post"
   },
+  "dependencies": {
+    "addon-sdk": "github:mozilla/addon-sdk"
+  },
   "devDependencies": {
+    "babel-plugin-import-rename": "^1.0.1",
     "babel-preset-es2015": "^6.6.0",
     "del": "^2.2.0",
     "eslint": "^2.13.1",
+    "eslint-plugin-import": "^1.10.2",
     "gulp": "github:gulpjs/gulp#4.0",
     "gulp-babel": "^6.1.2",
     "gulp-cli": "^1.2.1",
@@ -48,6 +53,12 @@
         {
           "async": false,
           "asyncGenerators": false
+        }
+      ],
+      [
+        "babel-plugin-import-rename",
+        {
+          "^(addon-sdk\/lib\/sdk)": "sdk"
         }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -2,8 +2,12 @@
   "name": "tab-wheel-scroll",
   "description": "Switch tabs by scrolling with the mouse wheel in the tab bar.",
   "version": "1.0.0",
-  "homepage": "http://github.com/mthamil/Tab-Wheel-Scroll",
   "author": "Matt Hamilton",
+  "homepage": "http://github.com/mthamil/Tab-Wheel-Scroll",
+    "repository": {
+    "type": "git",
+    "url": "https://github.com/mthamil/Tab-Wheel-Scroll.git"
+  },
   "scripts": {
     "start": "jpm --addon-dir ./dist run",
     "build": "gulp",

--- a/package.json
+++ b/package.json
@@ -26,41 +26,5 @@
     "gulp-json-editor": "^2.2.1",
     "jpm": "^1.0.7",
     "moment": "^2.13.0"
-  },
-  "babel": {
-    "plugins": [
-      "babel-plugin-transform-es2015-template-literals",
-      "babel-plugin-transform-es2015-literals",
-      "babel-plugin-transform-es2015-function-name",
-      "babel-plugin-transform-es2015-arrow-functions",
-      "babel-plugin-transform-es2015-block-scoped-functions",
-      "babel-plugin-transform-es2015-classes",
-      "babel-plugin-transform-es2015-object-super",
-      "babel-plugin-transform-es2015-shorthand-properties",
-      "babel-plugin-transform-es2015-duplicate-keys",
-      "babel-plugin-transform-es2015-computed-properties",
-      "babel-plugin-transform-es2015-sticky-regex",
-      "babel-plugin-transform-es2015-unicode-regex",
-      "babel-plugin-check-es2015-constants",
-      "babel-plugin-transform-es2015-spread",
-      "babel-plugin-transform-es2015-parameters",
-      "babel-plugin-transform-es2015-destructuring",
-      "babel-plugin-transform-es2015-block-scoping",
-      "babel-plugin-transform-es2015-typeof-symbol",
-      "babel-plugin-transform-es2015-modules-commonjs",
-      [
-        "babel-plugin-transform-regenerator",
-        {
-          "async": false,
-          "asyncGenerators": false
-        }
-      ],
-      [
-        "babel-plugin-import-rename",
-        {
-          "^(addon-sdk\/lib\/sdk)": "sdk"
-        }
-      ]
-    ]
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { WindowManager }  from "./lib/WindowManager";
 import { TabWheelScroll } from "./lib/TabWheelScroll";
 

--- a/src/lib/TabWheelScroll.js
+++ b/src/lib/TabWheelScroll.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as tabUtils from "./sdk/tabs/utils";
 import { viewFor }   from "addon-sdk/lib/sdk/view/core";
 import { prefs } 	 from "addon-sdk/lib/sdk/simple-prefs";

--- a/src/lib/TabWheelScroll.js
+++ b/src/lib/TabWheelScroll.js
@@ -1,8 +1,8 @@
 "use strict";
 
 import * as tabUtils from "./sdk/tabs/utils";
-import { viewFor }   from "sdk/view/core";
-import { prefs } 	 from "sdk/simple-prefs";
+import { viewFor }   from "addon-sdk/lib/sdk/view/core";
+import { prefs } 	 from "addon-sdk/lib/sdk/simple-prefs";
 
 class TabWheelScroll {
 	

--- a/src/lib/WindowManager.js
+++ b/src/lib/WindowManager.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { allWindows as windows } from "./sdk/windows";
 
 class WindowManager {

--- a/src/lib/sdk/core/heritage.js
+++ b/src/lib/sdk/core/heritage.js
@@ -1,5 +1,3 @@
-"use strict";
-
 /**
  * Helper function based on Babel.js plugin 'babel-plugin-transform-builtin-extend'
  * which fixes inheritance interop between classes created with the add-on sdk's Class() 

--- a/src/lib/sdk/tabs/utils.js
+++ b/src/lib/sdk/tabs/utils.js
@@ -1,6 +1,6 @@
 "use strict";
 
-import * as tabUtils from "sdk/tabs/utils";
+import * as tabUtils from "addon-sdk/lib/sdk/tabs/utils";
 
 function getTabContainer(window) {
     const tabMail = window.document.getElementById("tabmail");

--- a/src/lib/sdk/tabs/utils.js
+++ b/src/lib/sdk/tabs/utils.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as tabUtils from "addon-sdk/lib/sdk/tabs/utils";
 
 function getTabContainer(window) {

--- a/src/lib/sdk/windows.js
+++ b/src/lib/sdk/windows.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { browserWindows } from "addon-sdk/lib/sdk/windows";
 import { mailWindows }    from "./windows/mail";
 

--- a/src/lib/sdk/windows.js
+++ b/src/lib/sdk/windows.js
@@ -1,7 +1,7 @@
 "use strict";
 
-import { browserWindows } from "sdk/windows";
-import { mailWindows }   from "./windows/mail";
+import { browserWindows } from "addon-sdk/lib/sdk/windows";
+import { mailWindows }    from "./windows/mail";
 
 class ComposingIterator {
     constructor(iterators) {

--- a/src/lib/sdk/windows/mail.js
+++ b/src/lib/sdk/windows/mail.js
@@ -1,12 +1,12 @@
 "use strict";
 
-import * as windowUtils   from "sdk/window/utils";
-import { emit }           from "sdk/event/core";
-import { EventTarget }    from "sdk/event/target";
-import * as system        from "sdk/system";
-import { viewFor }        from "sdk/view/core";
-import { modelFor }       from "sdk/model/core";
-import { ns }             from "sdk/core/namespace";
+import * as windowUtils   from "addon-sdk/lib/sdk/window/utils";
+import { emit }           from "addon-sdk/lib/sdk/event/core";
+import { EventTarget }    from "addon-sdk/lib/sdk/event/target";
+import * as system        from "addon-sdk/lib/sdk/system";
+import { viewFor }        from "addon-sdk/lib/sdk/view/core";
+import { modelFor }       from "addon-sdk/lib/sdk/model/core";
+import { ns }             from "addon-sdk/lib/sdk/core/namespace";
 import { WindowObserver } from "./observer"
 import { Extendable }     from "../core/heritage"
 

--- a/src/lib/sdk/windows/mail.js
+++ b/src/lib/sdk/windows/mail.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as windowUtils   from "addon-sdk/lib/sdk/window/utils";
 import { emit }           from "addon-sdk/lib/sdk/event/core";
 import { EventTarget }    from "addon-sdk/lib/sdk/event/target";

--- a/src/lib/sdk/windows/observer.js
+++ b/src/lib/sdk/windows/observer.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import * as events from "addon-sdk/lib/sdk/system/events";
 import * as unload from "addon-sdk/lib/sdk/system/unload";
 

--- a/src/lib/sdk/windows/observer.js
+++ b/src/lib/sdk/windows/observer.js
@@ -1,7 +1,7 @@
 "use strict";
 
-import * as events from "sdk/system/events";
-import * as unload from "sdk/system/unload";
+import * as events from "addon-sdk/lib/sdk/system/events";
+import * as unload from "addon-sdk/lib/sdk/system/unload";
 
 class WindowObserver {
     constructor(onOpen, onClose) {

--- a/src/test/test-TabWheelScroll.js
+++ b/src/test/test-TabWheelScroll.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { run }                       from "addon-sdk/lib/sdk/test";
 import { browserWindows as windows } from "addon-sdk/lib/sdk/windows";
 import * as tabUtils                 from "addon-sdk/lib/sdk/tabs/utils";

--- a/src/test/test-TabWheelScroll.js
+++ b/src/test/test-TabWheelScroll.js
@@ -1,9 +1,9 @@
 "use strict";
 
-import { run }                       from "sdk/test";
-import { browserWindows as windows } from "sdk/windows";
-import * as tabUtils                 from "sdk/tabs/utils";
-import { viewFor }                   from "sdk/view/core";
+import { run }                       from "addon-sdk/lib/sdk/test";
+import { browserWindows as windows } from "addon-sdk/lib/sdk/windows";
+import * as tabUtils                 from "addon-sdk/lib/sdk/tabs/utils";
+import { viewFor }                   from "addon-sdk/lib/sdk/view/core";
 import { TabWheelScroll }            from "../lib/TabWheelScroll";
 
 function addOneTimeListener(target, name, handler, useCapture) {
@@ -14,7 +14,7 @@ function addOneTimeListener(target, name, handler, useCapture) {
     target.addEventListener(name, wrappingHandler, useCapture);
 }
 
-exports["test new TabWheelScroll"] = assert => {
+export function test_new_TabWheelScroll(assert) {
     // Arrange.
     const window = windows[0]
     
@@ -23,9 +23,9 @@ exports["test new TabWheelScroll"] = assert => {
     
     // Assert.
     assert.pass("Construction succeeded.");
-};
+}
 
-exports["test TabWheelScroll wheel scrolls up"] = (assert, done) => {
+export function test_TabWheelScroll_wheel_scrolls_up(assert, done) {
     // Arrange.
     const window = windows[0]
     const windowView = viewFor(window);
@@ -47,6 +47,6 @@ exports["test TabWheelScroll wheel scrolls up"] = (assert, done) => {
     
     // Act.
     tabContainer.dispatchEvent(new windowView.WheelEvent("wheel", { deltaY: -3 }));
-};
+}
 
 run(exports);

--- a/src/test/test-WindowManager.js
+++ b/src/test/test-WindowManager.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { run }                       from "addon-sdk/lib/sdk/test";
 import { browserWindows as windows } from "addon-sdk/lib/sdk/windows";
 import { WindowManager }             from "../lib/WindowManager";

--- a/src/test/test-WindowManager.js
+++ b/src/test/test-WindowManager.js
@@ -1,10 +1,10 @@
 "use strict";
 
-import { run }                       from "sdk/test";
-import { browserWindows as windows } from "sdk/windows";
+import { run }                       from "addon-sdk/lib/sdk/test";
+import { browserWindows as windows } from "addon-sdk/lib/sdk/windows";
 import { WindowManager }             from "../lib/WindowManager";
 
-exports["test new WindowManager"] = assert => {  
+export function test_new_WindowManager(assert) {  
     // Act.
     const underTest = new WindowManager(
         window => { window },
@@ -13,9 +13,9 @@ exports["test new WindowManager"] = assert => {
     // Assert.
     assert.equal(underTest.trackedWindows.size, 1, "Existing window should have been initialized.");
     assert.ok(underTest.trackedWindows.has(windows[0]), "Existing window should be tracked.");
-};
+}
 
-exports["test dispose WindowManager"] = assert => {  
+export function test_dispose_WindowManager(assert) {  
     // Arrange.
     const underTest = new WindowManager(
         window => { window },
@@ -26,9 +26,9 @@ exports["test dispose WindowManager"] = assert => {
     
     // Assert.
     assert.equal(underTest.trackedWindows.size, 0, "No windows should be tracked.");
-};
+}
 
-exports["test WindowManager with new window opened"] = (assert, done) => {
+export function test_WindowManager_with_new_window_opened(assert, done) {
     // Arrange.
     const underTest = new WindowManager(
         window => { window },
@@ -46,9 +46,9 @@ exports["test WindowManager with new window opened"] = (assert, done) => {
     
     // Act.
     windows.open({ url: "about:blank" });
-};
+}
 
-exports["test WindowManager with new window closed"] = (assert, done) => {
+export function test_WindowManager_with_new_window_closed(assert, done) {
     // Arrange.
     const originalWindow = windows[0];
     let newWindow = null;
@@ -74,6 +74,6 @@ exports["test WindowManager with new window closed"] = (assert, done) => {
             window.close();
         }
      });
-};
+}
 
 run(exports);

--- a/src/test/test-observer.js
+++ b/src/test/test-observer.js
@@ -1,5 +1,3 @@
-"use strict";
-
 import { run }            from "addon-sdk/lib/sdk/test";
 import { browserWindows } from "addon-sdk/lib/sdk/windows";
 import { WindowObserver } from "../lib/sdk/windows/observer";

--- a/src/test/test-observer.js
+++ b/src/test/test-observer.js
@@ -1,10 +1,10 @@
 "use strict";
 
-import { run }            from "sdk/test";
-import { browserWindows } from "sdk/windows";
-import { WindowObserver } from "../../../lib/sdk/windows/observer";
+import { run }            from "addon-sdk/lib/sdk/test";
+import { browserWindows } from "addon-sdk/lib/sdk/windows";
+import { WindowObserver } from "../lib/sdk/windows/observer";
 
-exports["test load event"] = (assert, done) => {
+export function test_load_event(assert, done) {
     
     // Arrange.
     let wasLoaded = false;
@@ -27,9 +27,9 @@ exports["test load event"] = (assert, done) => {
         
         done();
      });
-};
+}
 
-exports["test unload event"] = (assert, done) => {
+export function test_unload_event(assert, done) {
     
     // Arrange.
     let wasUnloaded = false;
@@ -49,6 +49,6 @@ exports["test unload event"] = (assert, done) => {
         url: "about:blank",
         onOpen: w => w.close()
     });
-};
+}
 
 run(exports);


### PR DESCRIPTION
- Added the eslint import plugin. 
- As a result, the Mozilla addon-sdk repo was added as a dependency. 
- A babeljs import path rewrite plugin was also added to convert the physical addon-sdk path into the correct path on build.
- Changed tests to use es2015 export and a few misc changes.
- Moved babel config into separate file.
