### PR TITLE
Enable e10s support.

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -61,7 +61,8 @@
   },
   "main": "index.js",
   "permissions": {
-    "private-browsing": true
+    "private-browsing": true,
+    "multiprocess": true
   },
   "preferences-branch": "extensions.tabscroll",
   "preferences": [


### PR DESCRIPTION
I've tested multiprocess support using Firefox Developer Edition and the add-on works fine.